### PR TITLE
Update JTAppleCalendar package version to 8.0.5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .library(name: "Fastis", targets: ["Fastis"])
     ],
     dependencies: [
-        .package(url: "https://github.com/patchthecode/JTAppleCalendar", from: "8.0.3"),
+        .package(url: "https://github.com/patchthecode/JTAppleCalendar", from: "8.0.5"),
         .package(url: "https://github.com/simla-tech/PrettyCards", from: "1.0.4")
     ],
     targets: [


### PR DESCRIPTION
This is to support Xcode 15, We have some compile errors on JTAppleCalendar 8.0.3